### PR TITLE
build: fix npm version of "mongodb-backup" and "mongodb-restore"

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -2,95 +2,185 @@
   "dependencies": {
     "busboy": {
       "version": "0.2.9",
+      "from": "busboy@0.2.9",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.9.tgz",
       "dependencies": {
         "dicer": {
           "version": "0.2.3",
+          "from": "dicer@0.2.3",
+          "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.3.tgz",
           "dependencies": {
             "streamsearch": {
-              "version": "0.1.2"
+              "version": "0.1.2",
+              "from": "streamsearch@0.1.2",
+              "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz"
             }
           }
         },
         "readable-stream": {
           "version": "1.1.13",
+          "from": "readable-stream@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
-              "version": "1.0.1"
+              "version": "1.0.1",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             },
             "isarray": {
-              "version": "0.0.1"
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
-              "version": "0.10.31"
+              "version": "0.10.31",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
-              "version": "2.0.1"
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         }
       }
     },
     "formidable": {
-      "version": "1.0.17"
+      "version": "1.0.17",
+      "from": "formidable@1.0.17",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
     },
     "moment": {
-      "version": "2.9.0"
+      "version": "2.9.0",
+      "from": "moment@2.9.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
     },
     "mongodb-backup": {
-      "version": "https://github.com/hex7c0/mongodb-backup/archive/681ea44bd9946dbf9d2ca7560362a60d199b0959.tar.gz",
+      "version": "1.3.0",
+      "from": "mongodb-backup@1.3.0",
+      "resolved": "https://registry.npmjs.org/mongodb-backup/-/mongodb-backup-1.3.0.tgz",
       "dependencies": {
         "bson": {
-          "version": "0.2.19",
-          "dependencies": {
-            "nan": {
-              "version": "1.6.2"
-            }
-          }
+          "version": "0.4.11",
+          "from": "bson@0.4.11",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.11.tgz"
         },
         "fstream": {
-          "version": "1.0.4",
+          "version": "1.0.7",
+          "from": "fstream@1.0.7",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
           "dependencies": {
             "graceful-fs": {
-              "version": "3.0.5"
+              "version": "3.0.8",
+              "from": "graceful-fs@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
             "inherits": {
-              "version": "2.0.1"
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "mkdirp": {
-              "version": "0.5.0",
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 >=0.0.0 <1.0.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
-                  "version": "0.0.8"
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "rimraf": {
-              "version": "2.2.8"
+              "version": "2.4.3",
+              "from": "rimraf@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.14",
+                  "from": "glob@>=5.0.14 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "balanced-match@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
             }
           }
         },
         "mongodb": {
-          "version": "2.0.16",
+          "version": "2.0.42",
+          "from": "mongodb@2.0.42",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.0.42.tgz",
           "dependencies": {
             "mongodb-core": {
-              "version": "1.1.12",
+              "version": "1.2.10",
+              "from": "mongodb-core@1.2.10",
+              "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.2.10.tgz",
               "dependencies": {
-                "mkdirp": {
-                  "version": "0.5.0",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8"
-                    }
-                  }
-                },
-                "rimraf": {
-                  "version": "2.2.6"
-                },
                 "kerberos": {
-                  "version": "0.0.9",
+                  "version": "0.0.12",
+                  "from": "kerberos@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.12.tgz",
                   "dependencies": {
                     "nan": {
-                      "version": "1.6.2"
+                      "version": "1.8.4",
+                      "from": "nan@>=1.8.0 <1.9.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
                     }
                   }
                 }
@@ -98,119 +188,163 @@
             },
             "readable-stream": {
               "version": "1.0.31",
+              "from": "readable-stream@1.0.31",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
               "dependencies": {
                 "core-util-is": {
-                  "version": "1.0.1"
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
-                  "version": "0.0.1"
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
-                  "version": "0.10.31"
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
-                  "version": "2.0.1"
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
+            },
+            "es6-promise": {
+              "version": "2.1.1",
+              "from": "es6-promise@2.1.1",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.1.1.tgz"
             }
           }
         },
         "logger-request": {
-          "version": "3.3.0",
+          "version": "3.4.0",
+          "from": "logger-request@3.4.0",
+          "resolved": "https://registry.npmjs.org/logger-request/-/logger-request-3.4.0.tgz",
           "dependencies": {
             "basic-authentication": {
-              "version": "1.5.11",
+              "version": "1.6.0",
+              "from": "basic-authentication@1.6.0",
+              "resolved": "https://registry.npmjs.org/basic-authentication/-/basic-authentication-1.6.0.tgz",
               "dependencies": {
                 "setheaders": {
-                  "version": "0.0.5"
+                  "version": "0.1.3",
+                  "from": "setheaders@0.1.3"
                 }
               }
             },
             "on-finished": {
-              "version": "2.2.0",
+              "version": "2.3.0",
+              "from": "on-finished@2.3.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "dependencies": {
                 "ee-first": {
-                  "version": "1.1.0"
+                  "version": "1.1.1",
+                  "from": "ee-first@1.1.1",
+                  "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                 }
               }
             },
             "transfer-rate": {
-              "version": "1.0.6"
+              "version": "1.1.1",
+              "from": "transfer-rate@1.1.1",
+              "resolved": "https://registry.npmjs.org/transfer-rate/-/transfer-rate-1.1.1.tgz"
             },
             "winston": {
-              "version": "0.9.0",
+              "version": "1.0.1",
+              "from": "winston@1.0.1",
+              "resolved": "https://registry.npmjs.org/winston/-/winston-1.0.1.tgz",
               "dependencies": {
                 "async": {
-                  "version": "0.9.0"
+                  "version": "0.9.2",
+                  "from": "async@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 },
                 "colors": {
-                  "version": "1.0.3"
+                  "version": "1.0.3",
+                  "from": "colors@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
                 },
                 "cycle": {
-                  "version": "1.0.3"
+                  "version": "1.0.3",
+                  "from": "cycle@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
                 },
                 "eyes": {
-                  "version": "0.1.8"
+                  "version": "0.1.8",
+                  "from": "eyes@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
                 },
                 "isstream": {
-                  "version": "0.1.1"
+                  "version": "0.1.2",
+                  "from": "isstream@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "pkginfo": {
-                  "version": "0.3.0"
+                  "version": "0.3.0",
+                  "from": "pkginfo@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
                 },
                 "stack-trace": {
-                  "version": "0.0.9"
+                  "version": "0.0.9",
+                  "from": "stack-trace@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
                 }
               }
             }
           }
         },
         "tar": {
-          "version": "1.0.3",
+          "version": "2.2.0",
+          "from": "tar@2.2.0",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.0.tgz",
           "dependencies": {
             "block-stream": {
-              "version": "0.0.7"
+              "version": "0.0.8",
+              "from": "block-stream@*",
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
             },
             "inherits": {
-              "version": "2.0.1"
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         }
       }
     },
     "mongodb-restore": {
-      "version": "https://github.com/hitchcott/mongodb-restore/archive/3bf27751b4d12eaddbba3149fc6d952d2fa4eecd.tar.gz",
+      "version": "1.3.0",
+      "from": "mongodb-restore@1.3.0",
+      "resolved": "https://registry.npmjs.org/mongodb-restore/-/mongodb-restore-1.3.0.tgz",
       "dependencies": {
         "bson": {
-          "version": "0.2.19",
-          "dependencies": {
-            "nan": {
-              "version": "1.6.2"
-            }
-          }
+          "version": "0.4.11",
+          "from": "bson@0.4.11",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.11.tgz"
         },
         "mongodb": {
-          "version": "2.0.18",
+          "version": "2.0.42",
+          "from": "mongodb@2.0.42",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.0.42.tgz",
           "dependencies": {
             "mongodb-core": {
-              "version": "1.1.14",
+              "version": "1.2.10",
+              "from": "mongodb-core@1.2.10",
+              "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.2.10.tgz",
               "dependencies": {
-                "mkdirp": {
-                  "version": "0.5.0",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8"
-                    }
-                  }
-                },
-                "rimraf": {
-                  "version": "2.2.6"
-                },
                 "kerberos": {
-                  "version": "0.0.9",
+                  "version": "0.0.12",
+                  "from": "kerberos@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.12.tgz",
                   "dependencies": {
                     "nan": {
-                      "version": "1.6.2"
+                      "version": "1.8.4",
+                      "from": "nan@>=1.8.0 <1.9.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
                     }
                   }
                 }
@@ -218,100 +352,220 @@
             },
             "readable-stream": {
               "version": "1.0.31",
+              "from": "readable-stream@1.0.31",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
               "dependencies": {
                 "core-util-is": {
-                  "version": "1.0.1"
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
-                  "version": "0.0.1"
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
-                  "version": "0.10.31"
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
-                  "version": "2.0.1"
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
+            },
+            "es6-promise": {
+              "version": "2.1.1",
+              "from": "es6-promise@2.1.1",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.1.1.tgz"
             }
           }
         },
         "logger-request": {
-          "version": "3.3.1",
+          "version": "3.4.0",
+          "from": "logger-request@3.4.0",
+          "resolved": "https://registry.npmjs.org/logger-request/-/logger-request-3.4.0.tgz",
           "dependencies": {
             "basic-authentication": {
-              "version": "1.5.12",
+              "version": "1.6.0",
+              "from": "basic-authentication@1.6.0",
+              "resolved": "https://registry.npmjs.org/basic-authentication/-/basic-authentication-1.6.0.tgz",
               "dependencies": {
                 "setheaders": {
-                  "version": "0.1.1"
+                  "version": "0.1.3",
+                  "from": "setheaders@0.1.3"
                 }
               }
             },
             "on-finished": {
-              "version": "2.2.0",
+              "version": "2.3.0",
+              "from": "on-finished@2.3.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "dependencies": {
                 "ee-first": {
-                  "version": "1.1.0"
+                  "version": "1.1.1",
+                  "from": "ee-first@1.1.1",
+                  "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                 }
               }
             },
             "transfer-rate": {
-              "version": "1.0.6"
+              "version": "1.1.1",
+              "from": "transfer-rate@1.1.1",
+              "resolved": "https://registry.npmjs.org/transfer-rate/-/transfer-rate-1.1.1.tgz"
             },
             "winston": {
-              "version": "0.9.0",
+              "version": "1.0.1",
+              "from": "winston@1.0.1",
+              "resolved": "https://registry.npmjs.org/winston/-/winston-1.0.1.tgz",
               "dependencies": {
                 "async": {
-                  "version": "0.9.0"
+                  "version": "0.9.2",
+                  "from": "async@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 },
                 "colors": {
-                  "version": "1.0.3"
+                  "version": "1.0.3",
+                  "from": "colors@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
                 },
                 "cycle": {
-                  "version": "1.0.3"
+                  "version": "1.0.3",
+                  "from": "cycle@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
                 },
                 "eyes": {
-                  "version": "0.1.8"
+                  "version": "0.1.8",
+                  "from": "eyes@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
                 },
                 "isstream": {
-                  "version": "0.1.1"
+                  "version": "0.1.2",
+                  "from": "isstream@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "pkginfo": {
-                  "version": "0.3.0"
+                  "version": "0.3.0",
+                  "from": "pkginfo@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
                 },
                 "stack-trace": {
-                  "version": "0.0.9"
+                  "version": "0.0.9",
+                  "from": "stack-trace@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
                 }
               }
             }
           }
         },
         "tar": {
-          "version": "1.0.3",
+          "version": "2.2.0",
+          "from": "tar@2.2.0",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.0.tgz",
           "dependencies": {
             "block-stream": {
-              "version": "0.0.7"
+              "version": "0.0.8",
+              "from": "block-stream@*",
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
             },
             "fstream": {
-              "version": "1.0.4",
+              "version": "1.0.7",
+              "from": "fstream@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
               "dependencies": {
                 "graceful-fs": {
-                  "version": "3.0.5"
+                  "version": "3.0.8",
+                  "from": "graceful-fs@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
                 },
                 "mkdirp": {
-                  "version": "0.5.0",
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.5.0 >=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
-                      "version": "0.0.8"
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "rimraf": {
-                  "version": "2.2.8"
+                  "version": "2.4.3",
+                  "from": "rimraf@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "5.0.14",
+                      "from": "glob@>=5.0.14 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "minimatch": {
+                          "version": "2.0.10",
+                          "from": "minimatch@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.0",
+                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.2.0",
+                                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.2",
+                          "from": "once@>=1.3.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             },
             "inherits": {
-              "version": "2.0.1"
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         }

--- a/package.js
+++ b/package.js
@@ -10,8 +10,8 @@ Npm.depends({
   "moment": "2.9.0",
   "formidable": "1.0.17",
   "busboy": "0.2.9",
-  "mongodb-backup": "https://github.com/hex7c0/mongodb-backup/archive/681ea44bd9946dbf9d2ca7560362a60d199b0959.tar.gz",
-  "mongodb-restore": "https://github.com/hitchcott/mongodb-restore/archive/3bf27751b4d12eaddbba3149fc6d952d2fa4eecd.tar.gz"
+  "mongodb-backup": "1.3.0",
+  "mongodb-restore": "1.3.0"
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
the previous version is releated to `1.0.2` on github repo
stream option is available since `1.1.0` version

latest version is released with iojs@3 test
