### PR TITLE
Fix "ReferenceError: check is not defined" error

### DIFF
--- a/package.js
+++ b/package.js
@@ -19,6 +19,7 @@ Package.onUse(function(api) {
 
   // SERVER
   api.use([
+    'check',
     'coffeescript',
     'iron:router@1.0.7' // for REST endpoint only
   ], ['server'])


### PR DESCRIPTION
For my Meteor 1.2.1 application, I got this error when trying to download backup:

```
ReferenceError: check is not defined at [object Object].route.action (packages/hitchcott_app-dump/app-dump-server.coffee:24:9) at boundNext (packages/iron_middleware-stack/lib/middleware_stack.js:251:1) at runWithEnvironment (packages/meteor/dynamics_nodejs.js:110:1) at packages/meteor/dynamics_nodejs.js:123:1 at [object Object].urlencodedParser (/Users/xxx/.meteor/packages/iron_router/.1.0.12.1iiabxy++os+web.browser+web.cordova/npm/node_modules/body-parser/lib/types/urlencoded.js:84:40) at packages/iron_router/lib/router.js:277:1 at [object Object]._.extend.withValue (packages/meteor/dynamics_nodejs.js:56:1) at [object Object].hookWithOptions (packages/iron_router/lib/router.js:276:1) at boundNext (packages/iron_middleware-stack/lib/middleware_stack.js:251:1) at runWithEnvironment (packages/meteor/dynamics_nodejs.js:110:1)
```

Looks like it is missing the "check" package as discussed [here](https://github.com/meteor/meteor/issues/5258).
